### PR TITLE
Fixe

### DIFF
--- a/Cookie/Core/Character.cs
+++ b/Cookie/Core/Character.cs
@@ -24,6 +24,7 @@ namespace Cookie.Core
             MapData = new MapData();
             Map = new Map(Client);
             GatherManager = new GatherManager(Client);
+            Jobs = new List<JobExperience>();
         }
 
         public DofusClient Client { get; set; }

--- a/Cookie/Handlers/Connection/ConnectionHandlers.cs
+++ b/Cookie/Handlers/Connection/ConnectionHandlers.cs
@@ -112,7 +112,7 @@ namespace Cookie.Handlers.Connection
         {
             foreach (var server in message.Servers)
             {
-                if (server.CharactersCount <= 0 || !server.IsSelectable) continue;
+                if (server.CharactersCount <= 0) continue;
                 switch ((ServerStatusEnum) server.Status)
                 {
                     case ServerStatusEnum.ONLINE:


### PR DESCRIPTION
Add initialisation Jobs dans la class Character
Et fixe de condition serveur.
J'ai retiré !server.IsSelectable car s'il est en sauvegarde, il est en IsSelectable = false
Donc direct il va sauter 

Maintenant il dit bien que le serveur est en save: 
https://puu.sh/wqNMd/0c5f59212b.png

Par contre à voir pour:
 default:
                        client.Logger.Log(D2OParsing.GetServerName(server.ObjectID) + ": " +
                                          (ServerStatusEnum) server.Status);

car il affiche en plus Menalt : SAVING comme ça à l'arrache sans rien d'autre ^^