### PR TITLE
Ajout d'une messagebox d'erreur quand l'utilisateur clique sur la map…

### DIFF
--- a/Cookie/Utils/MapControl.cs
+++ b/Cookie/Utils/MapControl.cs
@@ -148,7 +148,14 @@ namespace DofusMapControl
 
         private void OnCellClicked(MapCell cell, MouseButtons buttons, bool hold)
         {
-            CellClicked?.Invoke(this, cell, buttons, hold);
+            try
+            {
+                CellClicked?.Invoke(this, cell, buttons, hold);
+            } 
+            catch
+            {
+                MessageBox.Show("Une erreur est survenue... Le bot est-il bien lancé ?");
+            }
         }
 
         public event Action<MapControl, MapCell, MapCell> CellOver;


### PR DESCRIPTION
… sans que le bot soit lancé, afin d'éviter l’exception